### PR TITLE
Support key disposal

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -15,6 +15,8 @@
 #include <openssl/rand.h>
 #include <openssl/ripemd.h>
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -89,6 +91,11 @@ typedef struct {
   EVP_AEAD_CTX context;
 } bare_crypto_aead_t;
 
+typedef struct {
+  uint8_t *data;
+  size_t len;
+} bare_crypto_key_t;
+
 static inline const EVP_MD *
 bare_crypto__to_digest(js_env_t *env, int type) {
   int err;
@@ -162,6 +169,157 @@ bare_crypto__to_aead(js_env_t *env, int type) {
 
     return NULL;
   }
+}
+
+static void
+bare_crypto__key_set(bare_crypto_key_t *key, size_t len) {
+  if (key->data != NULL) {
+    OPENSSL_cleanse(key->data, key->len);
+    free(key->data);
+  }
+
+  key->len = len;
+  key->data = malloc(len);
+}
+
+static void
+bare_crypto_key_finalize(js_env_t *env, void *data, void *hint) {
+  bare_crypto_key_t *key = data;
+
+  if (key->data != NULL) {
+    OPENSSL_cleanse(key->data, key->len);
+    free(key->data);
+  }
+
+  free(key);
+}
+
+static js_value_t *
+bare_crypto_key_init(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 4;
+  js_value_t *argv[4];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 4);
+
+  uint8_t *buffer;
+  size_t buffer_cap;
+  err = js_get_arraybuffer_info(env, argv[1], (void **) &buffer, &buffer_cap);
+  assert(err == 0);
+
+  int64_t offset;
+  err = js_get_value_int64(env, argv[2], &offset);
+  assert(err == 0);
+
+  int64_t len;
+  err = js_get_value_int64(env, argv[3], &len);
+  assert(err == 0);
+
+  if (offset < 0 || len < 0 || offset + len > (int64_t) buffer_cap) {
+    err = js_throw_range_error(env, NULL, "Buffer out of range");
+    assert(err == 0);
+
+    return NULL;
+  }
+
+  bare_crypto_key_t *key = malloc(sizeof(bare_crypto_key_t));
+
+  key->len = len;
+  key->data = malloc(len);
+
+  memcpy(key->data, &buffer[offset], len);
+
+  err = js_wrap(env, argv[0], key, bare_crypto_key_finalize, NULL, NULL);
+  assert(err == 0);
+
+  return NULL;
+}
+
+static js_value_t *
+bare_crypto_key_export(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 1;
+  js_value_t *argv[1];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 1);
+
+  bare_crypto_key_t *key;
+  err = js_unwrap(env, argv[0], (void **) &key);
+  assert(err == 0);
+
+  if (key->data == NULL) {
+    err = js_throw_error(env, NULL, "Key has been destroyed");
+    assert(err == 0);
+
+    return NULL;
+  }
+
+  js_value_t *result;
+
+  uint8_t *out;
+  err = js_create_arraybuffer(env, key->len, (void **) &out, &result);
+  assert(err == 0);
+
+  memcpy(out, key->data, key->len);
+
+  return result;
+}
+
+static js_value_t *
+bare_crypto_key_destroy(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 1;
+  js_value_t *argv[1];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 1);
+
+  bare_crypto_key_t *key;
+  err = js_unwrap(env, argv[0], (void **) &key);
+  assert(err == 0);
+
+  if (key->data != NULL) {
+    OPENSSL_cleanse(key->data, key->len);
+    free(key->data);
+    key->data = NULL;
+    key->len = 0;
+  }
+
+  return NULL;
+}
+
+static js_value_t *
+bare_crypto_key_length(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 1;
+  js_value_t *argv[1];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 1);
+
+  bare_crypto_key_t *key;
+  err = js_unwrap(env, argv[0], (void **) &key);
+  assert(err == 0);
+
+  js_value_t *result;
+  err = js_create_uint32(env, key->len, &result);
+  assert(err == 0);
+
+  return result;
 }
 
 static js_value_t *
@@ -355,33 +513,42 @@ bare_crypto_ripemd160_final(js_env_t *env, js_callback_info_t *info) {
   return result;
 }
 
+static void
+bare_crypto_hmac_finalize(js_env_t *env, void *data, void *hint) {
+  bare_crypto_hmac_t *hmac = data;
+
+  HMAC_CTX_cleanup(&hmac->context);
+
+  free(hmac);
+}
+
 static js_value_t *
 bare_crypto_hmac_init(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  size_t argc = 4;
-  js_value_t *argv[4];
+  size_t argc = 5;
+  js_value_t *argv[5];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 4);
+  assert(argc == 5);
 
   uint32_t type;
-  err = js_get_value_uint32(env, argv[0], &type);
+  err = js_get_value_uint32(env, argv[1], &type);
   assert(err == 0);
 
   uint8_t *key;
   size_t key_cap;
-  err = js_get_arraybuffer_info(env, argv[1], (void **) &key, &key_cap);
+  err = js_get_arraybuffer_info(env, argv[2], (void **) &key, &key_cap);
   assert(err == 0);
 
   int64_t offset;
-  err = js_get_value_int64(env, argv[2], &offset);
+  err = js_get_value_int64(env, argv[3], &offset);
   assert(err == 0);
 
   int64_t len;
-  err = js_get_value_int64(env, argv[3], &len);
+  err = js_get_value_int64(env, argv[4], &len);
   assert(err == 0);
 
   if (offset < 0 || len < 0 || offset + len > (int64_t) key_cap) {
@@ -395,18 +562,17 @@ bare_crypto_hmac_init(js_env_t *env, js_callback_info_t *info) {
 
   if (algorithm == NULL) return NULL;
 
-  js_value_t *handle;
-
-  bare_crypto_hmac_t *hmac;
-  err = js_create_arraybuffer(env, sizeof(bare_crypto_hmac_t), (void **) &hmac, &handle);
-  assert(err == 0);
+  bare_crypto_hmac_t *hmac = malloc(sizeof(bare_crypto_hmac_t));
 
   HMAC_CTX_init(&hmac->context);
 
   err = HMAC_Init_ex(&hmac->context, &key[offset], len, algorithm, NULL);
   assert(err == 1);
 
-  return handle;
+  err = js_wrap(env, argv[0], hmac, bare_crypto_hmac_finalize, NULL, NULL);
+  assert(err == 0);
+
+  return NULL;
 }
 
 static js_value_t *
@@ -422,7 +588,7 @@ bare_crypto_hmac_update(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 4);
 
   bare_crypto_hmac_t *hmac;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &hmac, NULL);
+  err = js_unwrap(env, argv[0], (void **) &hmac);
   assert(err == 0);
 
   uint8_t *data;
@@ -464,7 +630,7 @@ bare_crypto_hmac_final(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 1);
 
   bare_crypto_hmac_t *hmac;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &hmac, NULL);
+  err = js_unwrap(env, argv[0], (void **) &hmac);
   assert(err == 0);
 
   js_value_t *result;
@@ -550,7 +716,7 @@ bare_crypto_cipher_block_size(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 1);
 
   bare_crypto_cipher_t *cipher;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &cipher, NULL);
+  err = js_unwrap(env, argv[0], (void **) &cipher);
   assert(err == 0);
 
   js_value_t *result;
@@ -560,33 +726,42 @@ bare_crypto_cipher_block_size(js_env_t *env, js_callback_info_t *info) {
   return result;
 }
 
+static void
+bare_crypto_cipher_finalize(js_env_t *env, void *data, void *hint) {
+  bare_crypto_cipher_t *cipher = data;
+
+  EVP_CIPHER_CTX_cleanup(&cipher->context);
+
+  free(cipher);
+}
+
 static js_value_t *
 bare_crypto_cipher_init(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  size_t argc = 8;
-  js_value_t *argv[8];
+  size_t argc = 9;
+  js_value_t *argv[9];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 8);
+  assert(argc == 9);
 
   uint32_t type;
-  err = js_get_value_uint32(env, argv[0], &type);
+  err = js_get_value_uint32(env, argv[1], &type);
   assert(err == 0);
 
   uint8_t *key;
   size_t key_cap;
-  err = js_get_arraybuffer_info(env, argv[1], (void **) &key, &key_cap);
+  err = js_get_arraybuffer_info(env, argv[2], (void **) &key, &key_cap);
   assert(err == 0);
 
   int64_t key_offset;
-  err = js_get_value_int64(env, argv[2], &key_offset);
+  err = js_get_value_int64(env, argv[3], &key_offset);
   assert(err == 0);
 
   int64_t key_len;
-  err = js_get_value_int64(env, argv[3], &key_len);
+  err = js_get_value_int64(env, argv[4], &key_len);
   assert(err == 0);
 
   if (key_offset < 0 || key_len < 0 || key_offset + key_len > (int64_t) key_cap) {
@@ -598,15 +773,15 @@ bare_crypto_cipher_init(js_env_t *env, js_callback_info_t *info) {
 
   uint8_t *iv;
   size_t iv_cap;
-  err = js_get_arraybuffer_info(env, argv[4], (void **) &iv, &iv_cap);
+  err = js_get_arraybuffer_info(env, argv[5], (void **) &iv, &iv_cap);
   assert(err == 0);
 
   int64_t iv_offset;
-  err = js_get_value_int64(env, argv[5], &iv_offset);
+  err = js_get_value_int64(env, argv[6], &iv_offset);
   assert(err == 0);
 
   int64_t iv_len;
-  err = js_get_value_int64(env, argv[6], &iv_len);
+  err = js_get_value_int64(env, argv[7], &iv_len);
   assert(err == 0);
 
   if (iv_offset < 0 || iv_len < 0 || iv_offset + iv_len > (int64_t) iv_cap) {
@@ -617,23 +792,22 @@ bare_crypto_cipher_init(js_env_t *env, js_callback_info_t *info) {
   }
 
   bool encrypt;
-  err = js_get_value_bool(env, argv[7], &encrypt);
-  assert(err == 0);
-
-  js_value_t *handle;
-
-  bare_crypto_cipher_t *cipher;
-  err = js_create_arraybuffer(env, sizeof(bare_crypto_cipher_t), (void **) &cipher, &handle);
+  err = js_get_value_bool(env, argv[8], &encrypt);
   assert(err == 0);
 
   const EVP_CIPHER *algorithm = bare_crypto__to_cipher(env, type);
 
   if (algorithm == NULL) return NULL;
 
+  bare_crypto_cipher_t *cipher = malloc(sizeof(bare_crypto_cipher_t));
+
   err = EVP_CipherInit(&cipher->context, algorithm, &key[key_offset], &iv[iv_offset], encrypt);
   assert(err == 1);
 
-  return handle;
+  err = js_wrap(env, argv[0], cipher, bare_crypto_cipher_finalize, NULL, NULL);
+  assert(err == 0);
+
+  return NULL;
 }
 
 static js_value_t *
@@ -649,7 +823,7 @@ bare_crypto_cipher_update(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 5);
 
   bare_crypto_cipher_t *cipher;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &cipher, NULL);
+  err = js_unwrap(env, argv[0], (void **) &cipher);
   assert(err == 0);
 
   uint8_t *data;
@@ -708,7 +882,7 @@ bare_crypto_cipher_final(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 2);
 
   bare_crypto_cipher_t *cipher;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &cipher, NULL);
+  err = js_unwrap(env, argv[0], (void **) &cipher);
   assert(err == 0);
 
   uint8_t *out;
@@ -755,7 +929,7 @@ bare_crypto_cipher_set_padding(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 2);
 
   bare_crypto_cipher_t *cipher;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &cipher, NULL);
+  err = js_unwrap(env, argv[0], (void **) &cipher);
   assert(err == 0);
 
   bool pad;
@@ -835,7 +1009,7 @@ bare_crypto_aead_max_overhead(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 1);
 
   bare_crypto_aead_t *aead;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &aead, NULL);
+  err = js_unwrap(env, argv[0], (void **) &aead);
   assert(err == 0);
 
   js_value_t *result;
@@ -858,7 +1032,7 @@ bare_crypto_aead_max_tag_length(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 1);
 
   bare_crypto_aead_t *aead;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &aead, NULL);
+  err = js_unwrap(env, argv[0], (void **) &aead);
   assert(err == 0);
 
   js_value_t *result;
@@ -868,33 +1042,42 @@ bare_crypto_aead_max_tag_length(js_env_t *env, js_callback_info_t *info) {
   return result;
 }
 
+static void
+bare_crypto_aead_finalize(js_env_t *env, void *data, void *hint) {
+  bare_crypto_aead_t *aead = data;
+
+  EVP_AEAD_CTX_cleanup(&aead->context);
+
+  free(aead);
+}
+
 static js_value_t *
 bare_crypto_aead_init(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  size_t argc = 5;
-  js_value_t *argv[5];
+  size_t argc = 6;
+  js_value_t *argv[6];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 5);
+  assert(argc == 6);
 
   uint32_t type;
-  err = js_get_value_uint32(env, argv[0], &type);
+  err = js_get_value_uint32(env, argv[1], &type);
   assert(err == 0);
 
   uint8_t *key;
   size_t key_cap;
-  err = js_get_arraybuffer_info(env, argv[1], (void **) &key, &key_cap);
+  err = js_get_arraybuffer_info(env, argv[2], (void **) &key, &key_cap);
   assert(err == 0);
 
   int64_t key_offset;
-  err = js_get_value_int64(env, argv[2], &key_offset);
+  err = js_get_value_int64(env, argv[3], &key_offset);
   assert(err == 0);
 
   int64_t key_len;
-  err = js_get_value_int64(env, argv[3], &key_len);
+  err = js_get_value_int64(env, argv[4], &key_len);
   assert(err == 0);
 
   if (key_offset < 0 || key_len < 0 || key_offset + key_len > (int64_t) key_cap) {
@@ -905,23 +1088,24 @@ bare_crypto_aead_init(js_env_t *env, js_callback_info_t *info) {
   }
 
   int64_t tag_len;
-  err = js_get_value_int64(env, argv[4], &tag_len);
-  assert(err == 0);
-
-  js_value_t *handle;
-
-  bare_crypto_aead_t *aead;
-  err = js_create_arraybuffer(env, sizeof(bare_crypto_aead_t), (void **) &aead, &handle);
+  err = js_get_value_int64(env, argv[5], &tag_len);
   assert(err == 0);
 
   const EVP_AEAD *algorithm = bare_crypto__to_aead(env, type);
 
   if (algorithm == NULL) return NULL;
 
+  bare_crypto_aead_t *aead = malloc(sizeof(bare_crypto_aead_t));
+
+  EVP_AEAD_CTX_zero(&aead->context);
+
   err = EVP_AEAD_CTX_init(&aead->context, algorithm, &key[key_offset], key_len, tag_len, NULL);
   assert(err == 1);
 
-  return handle;
+  err = js_wrap(env, argv[0], aead, bare_crypto_aead_finalize, NULL, NULL);
+  assert(err == 0);
+
+  return NULL;
 }
 
 static js_value_t *
@@ -937,7 +1121,7 @@ bare_crypto_aead_seal(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 11);
 
   bare_crypto_aead_t *aead;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &aead, NULL);
+  err = js_unwrap(env, argv[0], (void **) &aead);
   assert(err == 0);
 
   uint8_t *data;
@@ -1048,7 +1232,7 @@ bare_crypto_aead_open(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 11);
 
   bare_crypto_aead_t *aead;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &aead, NULL);
+  err = js_unwrap(env, argv[0], (void **) &aead);
   assert(err == 0);
 
   uint8_t *data;
@@ -1150,29 +1334,28 @@ static js_value_t *
 bare_crypto_ed25519_generate_keypair(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  js_value_t *result;
-  err = js_create_object(env, &result);
+  size_t argc = 2;
+  js_value_t *argv[2];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  js_value_t *handle;
+  assert(argc == 2);
 
-  uint8_t *public_key;
-  err = js_create_arraybuffer(env, ED25519_PUBLIC_KEY_LEN, (void **) &public_key, &handle);
+  bare_crypto_key_t *public_key;
+  err = js_unwrap(env, argv[0], (void **) &public_key);
   assert(err == 0);
 
-  err = js_set_named_property(env, result, "publicKey", handle);
+  bare_crypto_key_t *private_key;
+  err = js_unwrap(env, argv[1], (void **) &private_key);
   assert(err == 0);
 
-  uint8_t *private_key;
-  err = js_create_arraybuffer(env, ED25519_PRIVATE_KEY_LEN, (void **) &private_key, &handle);
-  assert(err == 0);
+  bare_crypto__key_set(public_key, ED25519_PUBLIC_KEY_LEN);
+  bare_crypto__key_set(private_key, ED25519_PRIVATE_KEY_LEN);
 
-  err = js_set_named_property(env, result, "privateKey", handle);
-  assert(err == 0);
+  ED25519_keypair(public_key->data, private_key->data);
 
-  ED25519_keypair(public_key, private_key);
-
-  return result;
+  return NULL;
 }
 
 static js_value_t *
@@ -1207,12 +1390,11 @@ bare_crypto_ed25519_sign(js_env_t *env, js_callback_info_t *info) {
     return NULL;
   }
 
-  uint8_t *private_key;
-  size_t private_key_cap;
-  err = js_get_arraybuffer_info(env, argv[3], (void **) &private_key, &private_key_cap);
+  bare_crypto_key_t *private_key;
+  err = js_unwrap(env, argv[3], (void **) &private_key);
   assert(err == 0);
 
-  if (private_key_cap < ED25519_PRIVATE_KEY_LEN) {
+  if (private_key->data == NULL || private_key->len < ED25519_PRIVATE_KEY_LEN) {
     err = js_throw_range_error(env, NULL, "Buffer out of range");
     assert(err == 0);
 
@@ -1225,7 +1407,7 @@ bare_crypto_ed25519_sign(js_env_t *env, js_callback_info_t *info) {
   err = js_create_arraybuffer(env, ED25519_SIGNATURE_LEN, (void **) &signature, &handle);
   assert(err == 0);
 
-  err = ED25519_sign(signature, &data[offset], len, private_key);
+  err = ED25519_sign(signature, &data[offset], len, private_key->data);
   assert(err == 1);
 
   return handle;
@@ -1279,12 +1461,11 @@ bare_crypto_ed25519_verify(js_env_t *env, js_callback_info_t *info) {
     return NULL;
   }
 
-  uint8_t *public_key;
-  size_t public_key_cap;
-  err = js_get_arraybuffer_info(env, argv[5], (void **) &public_key, &public_key_cap);
+  bare_crypto_key_t *public_key;
+  err = js_unwrap(env, argv[5], (void **) &public_key);
   assert(err == 0);
 
-  if (public_key_cap < ED25519_PUBLIC_KEY_LEN) {
+  if (public_key->data == NULL || public_key->len < ED25519_PUBLIC_KEY_LEN) {
     err = js_throw_range_error(env, NULL, "Buffer out of range");
     assert(err == 0);
 
@@ -1292,7 +1473,7 @@ bare_crypto_ed25519_verify(js_env_t *env, js_callback_info_t *info) {
   }
 
   js_value_t *result;
-  err = js_get_boolean(env, ED25519_verify(&data[data_offset], data_len, &signature[signature_offset], public_key), &result);
+  err = js_get_boolean(env, ED25519_verify(&data[data_offset], data_len, &signature[signature_offset], public_key->data), &result);
   assert(err == 0);
 
   return result;
@@ -1310,19 +1491,18 @@ bare_crypto_ed25519_to_spki(js_env_t *env, js_callback_info_t *info) {
 
   assert(argc == 1);
 
-  uint8_t *public_key;
-  size_t public_key_cap;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &public_key, &public_key_cap);
+  bare_crypto_key_t *public_key;
+  err = js_unwrap(env, argv[0], (void **) &public_key);
   assert(err == 0);
 
-  if (public_key_cap < ED25519_PUBLIC_KEY_LEN) {
+  if (public_key->data == NULL || public_key->len < ED25519_PUBLIC_KEY_LEN) {
     err = js_throw_range_error(env, NULL, "Buffer out of range");
     assert(err == 0);
 
     return NULL;
   }
 
-  EVP_PKEY *pkey = EVP_PKEY_new_raw_public_key(EVP_PKEY_ED25519, NULL, public_key, 32);
+  EVP_PKEY *pkey = EVP_PKEY_new_raw_public_key(EVP_PKEY_ED25519, NULL, public_key->data, 32);
 
   CBB bytes;
   err = CBB_init(&bytes, 0);
@@ -1355,25 +1535,29 @@ static js_value_t *
 bare_crypto_ed25519_from_spki(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  size_t argc = 3;
-  js_value_t *argv[3];
+  size_t argc = 4;
+  js_value_t *argv[4];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 3);
+  assert(argc == 4);
+
+  bare_crypto_key_t *public_key;
+  err = js_unwrap(env, argv[0], (void **) &public_key);
+  assert(err == 0);
 
   uint8_t *der;
   size_t der_cap;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &der, &der_cap);
+  err = js_get_arraybuffer_info(env, argv[1], (void **) &der, &der_cap);
   assert(err == 0);
 
   int64_t offset;
-  err = js_get_value_int64(env, argv[1], &offset);
+  err = js_get_value_int64(env, argv[2], &offset);
   assert(err == 0);
 
   int64_t len;
-  err = js_get_value_int64(env, argv[2], &len);
+  err = js_get_value_int64(env, argv[3], &len);
   assert(err == 0);
 
   if (offset < 0 || len < 0 || offset + len > (int64_t) der_cap) {
@@ -1395,14 +1579,10 @@ bare_crypto_ed25519_from_spki(js_env_t *env, js_callback_info_t *info) {
     return NULL;
   }
 
-  js_value_t *handle;
-
-  uint8_t *public_key;
-  err = js_create_arraybuffer(env, ED25519_PUBLIC_KEY_LEN, (void **) &public_key, &handle);
-  assert(err == 0);
+  bare_crypto__key_set(public_key, ED25519_PUBLIC_KEY_LEN);
 
   size_t written = ED25519_PUBLIC_KEY_LEN;
-  err = EVP_PKEY_get_raw_public_key(pkey, public_key, &written);
+  err = EVP_PKEY_get_raw_public_key(pkey, public_key->data, &written);
 
   EVP_PKEY_free(pkey);
 
@@ -1413,7 +1593,7 @@ bare_crypto_ed25519_from_spki(js_env_t *env, js_callback_info_t *info) {
     return NULL;
   }
 
-  return handle;
+  return NULL;
 }
 
 static js_value_t *
@@ -1428,19 +1608,18 @@ bare_crypto_ed25519_to_pkcs8(js_env_t *env, js_callback_info_t *info) {
 
   assert(argc == 1);
 
-  uint8_t *private_key;
-  size_t private_key_cap;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &private_key, &private_key_cap);
+  bare_crypto_key_t *private_key;
+  err = js_unwrap(env, argv[0], (void **) &private_key);
   assert(err == 0);
 
-  if (private_key_cap < ED25519_PRIVATE_KEY_LEN) {
+  if (private_key->data == NULL || private_key->len < ED25519_PRIVATE_KEY_LEN) {
     err = js_throw_range_error(env, NULL, "Buffer out of range");
     assert(err == 0);
 
     return NULL;
   }
 
-  EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL, private_key, 32);
+  EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL, private_key->data, 32);
 
   CBB bytes;
   err = CBB_init(&bytes, 0);
@@ -1474,25 +1653,29 @@ static js_value_t *
 bare_crypto_ed25519_from_pkcs8(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  size_t argc = 3;
-  js_value_t *argv[3];
+  size_t argc = 4;
+  js_value_t *argv[4];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 3);
+  assert(argc == 4);
+
+  bare_crypto_key_t *private_key;
+  err = js_unwrap(env, argv[0], (void **) &private_key);
+  assert(err == 0);
 
   uint8_t *der;
   size_t der_cap;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &der, &der_cap);
+  err = js_get_arraybuffer_info(env, argv[1], (void **) &der, &der_cap);
   assert(err == 0);
 
   int64_t offset;
-  err = js_get_value_int64(env, argv[1], &offset);
+  err = js_get_value_int64(env, argv[2], &offset);
   assert(err == 0);
 
   int64_t len;
-  err = js_get_value_int64(env, argv[2], &len);
+  err = js_get_value_int64(env, argv[3], &len);
   assert(err == 0);
 
   if (offset < 0 || len < 0 || offset + len > (int64_t) der_cap) {
@@ -1514,14 +1697,10 @@ bare_crypto_ed25519_from_pkcs8(js_env_t *env, js_callback_info_t *info) {
     return NULL;
   }
 
-  js_value_t *handle;
-
-  uint8_t *private_key;
-  err = js_create_arraybuffer(env, ED25519_PRIVATE_KEY_LEN, (void **) &private_key, &handle);
-  assert(err == 0);
+  bare_crypto__key_set(private_key, ED25519_PRIVATE_KEY_LEN);
 
   size_t written = ED25519_PRIVATE_KEY_LEN;
-  err = EVP_PKEY_get_raw_private_key(pkey, private_key, &written);
+  err = EVP_PKEY_get_raw_private_key(pkey, private_key->data, &written);
 
   if (err != 1) {
     EVP_PKEY_free(pkey);
@@ -1533,7 +1712,7 @@ bare_crypto_ed25519_from_pkcs8(js_env_t *env, js_callback_info_t *info) {
   }
 
   written = ED25519_PUBLIC_KEY_LEN;
-  err = EVP_PKEY_get_raw_public_key(pkey, &private_key[32], &written);
+  err = EVP_PKEY_get_raw_public_key(pkey, &private_key->data[32], &written);
 
   EVP_PKEY_free(pkey);
 
@@ -1544,7 +1723,7 @@ bare_crypto_ed25519_from_pkcs8(js_env_t *env, js_callback_info_t *info) {
     return NULL;
   }
 
-  return handle;
+  return NULL;
 }
 
 static js_value_t *
@@ -1745,6 +1924,11 @@ bare_crypto_exports(js_env_t *env, js_value_t *exports) {
     err = js_set_named_property(env, exports, name, val); \
     assert(err == 0); \
   }
+
+  V("keyInit", bare_crypto_key_init)
+  V("keyExport", bare_crypto_key_export)
+  V("keyDestroy", bare_crypto_key_destroy)
+  V("keyLength", bare_crypto_key_length)
 
   V("digestInit", bare_crypto_digest_init)
   V("digestUpdate", bare_crypto_digest_update)

--- a/binding.c
+++ b/binding.c
@@ -1398,7 +1398,14 @@ bare_crypto_ed25519_sign(js_env_t *env, js_callback_info_t *info) {
   err = js_unwrap(env, argv[3], (void **) &private_key);
   assert(err == 0);
 
-  if (private_key->data == NULL || private_key->len < ED25519_PRIVATE_KEY_LEN) {
+  if (private_key->data == NULL) {
+    err = js_throw_error(env, NULL, "Key has been destroyed");
+    assert(err == 0);
+
+    return NULL;
+  }
+
+  if (private_key->len < ED25519_PRIVATE_KEY_LEN) {
     err = js_throw_range_error(env, NULL, "Buffer out of range");
     assert(err == 0);
 
@@ -1469,7 +1476,14 @@ bare_crypto_ed25519_verify(js_env_t *env, js_callback_info_t *info) {
   err = js_unwrap(env, argv[5], (void **) &public_key);
   assert(err == 0);
 
-  if (public_key->data == NULL || public_key->len < ED25519_PUBLIC_KEY_LEN) {
+  if (public_key->data == NULL) {
+    err = js_throw_error(env, NULL, "Key has been destroyed");
+    assert(err == 0);
+
+    return NULL;
+  }
+
+  if (public_key->len < ED25519_PUBLIC_KEY_LEN) {
     err = js_throw_range_error(env, NULL, "Buffer out of range");
     assert(err == 0);
 
@@ -1499,7 +1513,14 @@ bare_crypto_ed25519_to_spki(js_env_t *env, js_callback_info_t *info) {
   err = js_unwrap(env, argv[0], (void **) &public_key);
   assert(err == 0);
 
-  if (public_key->data == NULL || public_key->len < ED25519_PUBLIC_KEY_LEN) {
+  if (public_key->data == NULL) {
+    err = js_throw_error(env, NULL, "Key has been destroyed");
+    assert(err == 0);
+
+    return NULL;
+  }
+
+  if (public_key->len < ED25519_PUBLIC_KEY_LEN) {
     err = js_throw_range_error(env, NULL, "Buffer out of range");
     assert(err == 0);
 
@@ -1616,7 +1637,14 @@ bare_crypto_ed25519_to_pkcs8(js_env_t *env, js_callback_info_t *info) {
   err = js_unwrap(env, argv[0], (void **) &private_key);
   assert(err == 0);
 
-  if (private_key->data == NULL || private_key->len < ED25519_PRIVATE_KEY_LEN) {
+  if (private_key->data == NULL) {
+    err = js_throw_error(env, NULL, "Key has been destroyed");
+    assert(err == 0);
+
+    return NULL;
+  }
+
+  if (private_key->len < ED25519_PRIVATE_KEY_LEN) {
     err = js_throw_range_error(env, NULL, "Buffer out of range");
     assert(err == 0);
 

--- a/binding.c
+++ b/binding.c
@@ -175,6 +175,7 @@ static void
 bare_crypto__key_set(bare_crypto_key_t *key, size_t len) {
   if (key->data != NULL) {
     OPENSSL_cleanse(key->data, key->len);
+
     free(key->data);
   }
 
@@ -188,6 +189,7 @@ bare_crypto_key_finalize(js_env_t *env, void *data, void *hint) {
 
   if (key->data != NULL) {
     OPENSSL_cleanse(key->data, key->len);
+
     free(key->data);
   }
 
@@ -291,7 +293,9 @@ bare_crypto_key_destroy(js_env_t *env, js_callback_info_t *info) {
 
   if (key->data != NULL) {
     OPENSSL_cleanse(key->data, key->len);
+
     free(key->data);
+
     key->data = NULL;
     key->len = 0;
   }

--- a/lib/cipher.js
+++ b/lib/cipher.js
@@ -64,13 +64,7 @@ class CryptoCipher {
 
     const out = new ArrayBuffer(data.byteLength + binding.cipherBlockSize(this))
 
-    const written = binding.cipherUpdate(
-      this,
-      data.buffer,
-      data.byteOffset,
-      data.byteLength,
-      out
-    )
+    const written = binding.cipherUpdate(this, data.buffer, data.byteOffset, data.byteLength, out)
 
     const result = Buffer.from(out, 0, written)
 
@@ -131,14 +125,7 @@ class CryptoAuthenticatedCipher {
     this._additionalData = null
     this._finalized = false
 
-    binding.aeadInit(
-      this,
-      algorithm,
-      key.buffer,
-      key.byteOffset,
-      key.byteLength,
-      authTagLength
-    )
+    binding.aeadInit(this, algorithm, key.buffer, key.byteOffset, key.byteLength, authTagLength)
   }
 
   update(data, inputEncoding = 'utf8', outputEncoding) {

--- a/lib/cipher.js
+++ b/lib/cipher.js
@@ -38,7 +38,10 @@ class CryptoCipher {
       throw new RangeError('Invalid iv length')
     }
 
-    this._handle = binding.cipherInit(
+    this._finalized = false
+
+    binding.cipherInit(
+      this,
       algorithm,
       key.buffer,
       key.byteOffset,
@@ -51,7 +54,7 @@ class CryptoCipher {
   }
 
   update(data, inputEncoding = 'utf8', outputEncoding) {
-    if (this._handle === null) {
+    if (this._finalized) {
       throw new Error('Cipher has already been finalized')
     }
 
@@ -59,10 +62,10 @@ class CryptoCipher {
 
     assert(ArrayBuffer.isView(data))
 
-    const out = new ArrayBuffer(data.byteLength + binding.cipherBlockSize(this._handle))
+    const out = new ArrayBuffer(data.byteLength + binding.cipherBlockSize(this))
 
     const written = binding.cipherUpdate(
-      this._handle,
+      this,
       data.buffer,
       data.byteOffset,
       data.byteLength,
@@ -75,15 +78,15 @@ class CryptoCipher {
   }
 
   final(outputEncoding) {
-    if (this._handle === null) {
+    if (this._finalized) {
       throw new Error('Cipher has already been finalized')
     }
 
-    const out = new ArrayBuffer(binding.cipherBlockSize(this._handle))
+    const out = new ArrayBuffer(binding.cipherBlockSize(this))
 
-    const written = binding.cipherFinal(this._handle, out)
+    const written = binding.cipherFinal(this, out)
 
-    this._handle = null
+    this._finalized = true
 
     const result = Buffer.from(out, 0, written)
 
@@ -91,11 +94,11 @@ class CryptoCipher {
   }
 
   setAutoPadding(pad) {
-    if (this._handle === null) {
+    if (this._finalized) {
       throw new Error('Cipher has already been finalized')
     }
 
-    binding.cipherSetPadding(this._handle, pad)
+    binding.cipherSetPadding(this, pad)
   }
 }
 
@@ -126,8 +129,10 @@ class CryptoAuthenticatedCipher {
     this._authTag = null
     this._authTagLength = authTagLength
     this._additionalData = null
+    this._finalized = false
 
-    this._handle = binding.aeadInit(
+    binding.aeadInit(
+      this,
       algorithm,
       key.buffer,
       key.byteOffset,
@@ -171,7 +176,7 @@ class CryptoAuthenticatedCipher {
 
 class CryptoAuthenticatedSeal extends CryptoAuthenticatedCipher {
   final(outputEncoding) {
-    if (this._handle === null) {
+    if (this._finalized) {
       throw new Error('Cipher has already been finalized')
     }
 
@@ -180,10 +185,10 @@ class CryptoAuthenticatedSeal extends CryptoAuthenticatedCipher {
     const nonce = this._nonce
     const ad = this._additionalData || Buffer.alloc(0)
 
-    const out = new ArrayBuffer(data.byteLength + binding.aeadMaxOverhead(this._handle))
+    const out = new ArrayBuffer(data.byteLength + binding.aeadMaxOverhead(this))
 
     const written = binding.aeadSeal(
-      this._handle,
+      this,
       data.buffer,
       data.byteOffset,
       data.byteLength,
@@ -196,7 +201,7 @@ class CryptoAuthenticatedSeal extends CryptoAuthenticatedCipher {
       out
     )
 
-    this._handle = null
+    this._finalized = true
 
     const cipherLength = written - this._authTagLength
 
@@ -210,7 +215,7 @@ class CryptoAuthenticatedSeal extends CryptoAuthenticatedCipher {
 
 class CryptoAuthenticatedOpen extends CryptoAuthenticatedCipher {
   final(outputEncoding) {
-    if (this._handle === null) {
+    if (this._finalized) {
       throw new Error('Decipher has already been finalized')
     }
 
@@ -224,7 +229,7 @@ class CryptoAuthenticatedOpen extends CryptoAuthenticatedCipher {
     const out = new ArrayBuffer(data.byteLength)
 
     const written = binding.aeadOpen(
-      this._handle,
+      this,
       data.buffer,
       data.byteOffset,
       data.byteLength,
@@ -237,7 +242,7 @@ class CryptoAuthenticatedOpen extends CryptoAuthenticatedCipher {
       out
     )
 
-    this._handle = null
+    this._finalized = true
 
     const result = Buffer.from(out, 0, written)
 

--- a/lib/hmac.js
+++ b/lib/hmac.js
@@ -13,7 +13,10 @@ module.exports = class CryptoHmac extends Transform {
 
     assert(ArrayBuffer.isView(key))
 
-    this._handle = binding.hmacInit(
+    this._finalized = false
+
+    binding.hmacInit(
+      this,
       constants.toHash(algorithm),
       key.buffer,
       key.byteOffset,
@@ -22,7 +25,7 @@ module.exports = class CryptoHmac extends Transform {
   }
 
   update(data, encoding = 'utf8') {
-    if (this._handle === null) {
+    if (this._finalized) {
       throw new Error('Hmac has already been finalized')
     }
 
@@ -30,18 +33,18 @@ module.exports = class CryptoHmac extends Transform {
 
     assert(ArrayBuffer.isView(data))
 
-    binding.hmacUpdate(this._handle, data.buffer, data.byteOffset, data.byteLength)
+    binding.hmacUpdate(this, data.buffer, data.byteOffset, data.byteLength)
 
     return this
   }
 
   digest(encoding) {
-    if (this._handle === null) {
+    if (this._finalized) {
       throw new Error('Hmac has already been finalized')
     }
 
-    const digest = Buffer.from(binding.hmacFinal(this._handle))
-    this._handle = null
+    const digest = Buffer.from(binding.hmacFinal(this))
+    this._finalized = true
 
     return encoding && encoding !== 'buffer' ? digest.toString(encoding) : digest
   }

--- a/lib/hmac.js
+++ b/lib/hmac.js
@@ -15,13 +15,7 @@ module.exports = class CryptoHmac extends Transform {
 
     this._finalized = false
 
-    binding.hmacInit(
-      this,
-      constants.toHash(algorithm),
-      key.buffer,
-      key.byteOffset,
-      key.byteLength
-    )
+    binding.hmacInit(this, constants.toHash(algorithm), key.buffer, key.byteOffset, key.byteLength)
   }
 
   update(data, encoding = 'utf8') {

--- a/lib/key.d.ts
+++ b/lib/key.d.ts
@@ -1,3 +1,4 @@
+import Buffer from 'bare-buffer'
 import { type SignatureAlgorithm } from './signature'
 
 declare class CryptoKey {
@@ -5,7 +6,7 @@ declare class CryptoKey {
 
   readonly destroyed: boolean
 
-  export(): ArrayBuffer
+  export(): Buffer
 
   destroy(): void
 

--- a/lib/key.d.ts
+++ b/lib/key.d.ts
@@ -1,17 +1,15 @@
 import { type SignatureAlgorithm } from './signature'
 
-declare class CryptoKey {}
+declare class CryptoKey {
+  readonly type: 'public' | 'private' | 'secret'
 
-declare class CryptoEd25519Key extends CryptoKey {
-  readonly asymmetricKeyType: 'ed25519'
-}
+  readonly destroyed: boolean
 
-declare class CryptoEd25519PublicKey extends CryptoEd25519Key {
-  readonly type: 'public'
-}
+  export(): ArrayBuffer
 
-declare class CryptoEd25519PrivateKey extends CryptoEd25519Key {
-  readonly type: 'private'
+  destroy(): void
+
+  [Symbol.dispose](): void
 }
 
 declare function generateKeyPair(type: SignatureAlgorithm | Lowercase<SignatureAlgorithm>): {
@@ -19,9 +17,4 @@ declare function generateKeyPair(type: SignatureAlgorithm | Lowercase<SignatureA
   privateKey: CryptoKey
 }
 
-export {
-  CryptoKey as Key,
-  CryptoEd25519PublicKey as Ed25519PublicKey,
-  CryptoEd25519PrivateKey as Ed25519PrivateKey,
-  generateKeyPair
-}
+export { CryptoKey as Key, generateKeyPair }

--- a/lib/key.js
+++ b/lib/key.js
@@ -59,7 +59,7 @@ class CryptoEd25519Key extends CryptoKey {
       throw new Error('Key has been destroyed')
     }
 
-    return binding.keyExport(this)
+    return Buffer.from(binding.keyExport(this))
   }
 
   destroy() {
@@ -113,7 +113,7 @@ class CryptoSecretKey extends CryptoKey {
       throw new Error('Key has been destroyed')
     }
 
-    return binding.keyExport(this)
+    return Buffer.from(binding.keyExport(this))
   }
 
   destroy() {

--- a/lib/key.js
+++ b/lib/key.js
@@ -9,19 +9,65 @@ class CryptoKey {
   constructor(keyType) {
     this._keyType = keyType
   }
+
+  get type() {
+    throw new Error('Not implemented')
+  }
+
+  get destroyed() {
+    return false
+  }
+
+  export() {
+    throw new Error('Not implemented')
+  }
+
+  destroy() {}
+
+  [Symbol.dispose]() {
+    this.destroy()
+  }
 }
 
 exports.Key = CryptoKey
 
 class CryptoEd25519Key extends CryptoKey {
-  constructor(key) {
+  constructor(key = null) {
     super(ED25519)
 
-    this._key = key
+    this._destroyed = false
+
+    if (key === null) {
+      binding.keyInit(this, new ArrayBuffer(0), 0, 0)
+    } else if (ArrayBuffer.isView(key)) {
+      binding.keyInit(this, key.buffer, key.byteOffset, key.byteLength)
+    } else {
+      binding.keyInit(this, key, 0, key.byteLength)
+    }
   }
 
   get asymmetricKeyType() {
     return 'ed25519'
+  }
+
+  get destroyed() {
+    return this._destroyed
+  }
+
+  export() {
+    if (this._destroyed) {
+      throw new Error('Key has been destroyed')
+    }
+
+    return binding.keyExport(this)
+  }
+
+  destroy() {
+    if (this._destroyed) return
+
+    binding.keyDestroy(this)
+
+    this._destroyed = true
   }
 }
 
@@ -41,17 +87,57 @@ class CryptoEd25519PrivateKey extends CryptoEd25519Key {
 
 exports.Ed25519PrivateKey = CryptoEd25519PrivateKey
 
+class CryptoSecretKey extends CryptoKey {
+  constructor(key) {
+    super()
+
+    this._destroyed = false
+
+    if (ArrayBuffer.isView(key)) {
+      binding.keyInit(this, key.buffer, key.byteOffset, key.byteLength)
+    } else {
+      binding.keyInit(this, key, 0, key.byteLength)
+    }
+  }
+
+  get type() {
+    return 'secret'
+  }
+
+  get destroyed() {
+    return this._destroyed
+  }
+
+  export() {
+    if (this._destroyed) {
+      throw new Error('Key has been destroyed')
+    }
+
+    return binding.keyExport(this)
+  }
+
+  destroy() {
+    if (this._destroyed) return
+
+    binding.keyDestroy(this)
+
+    this._destroyed = true
+  }
+}
+
+exports.SecretKey = CryptoSecretKey
+
 exports.generateKeyPair = function generateKeyPair(type) {
   type = constants.toKeyType(type)
 
   switch (type) {
     case ED25519: {
-      const { publicKey, privateKey } = binding.ed25519GenerateKeypair()
+      const publicKey = new CryptoEd25519PublicKey()
+      const privateKey = new CryptoEd25519PrivateKey()
 
-      return {
-        publicKey: new CryptoEd25519PublicKey(publicKey),
-        privateKey: new CryptoEd25519PrivateKey(privateKey)
-      }
+      binding.ed25519GenerateKeypair(publicKey, privateKey)
+
+      return { publicKey, privateKey }
     }
   }
 }

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -21,7 +21,7 @@ exports.sign = function sign(algorithm, data, key) {
   switch (key._keyType) {
     case ED25519:
       return Buffer.from(
-        binding.ed25519Sign(data.buffer, data.byteOffset, data.byteLength, key._key)
+        binding.ed25519Sign(data.buffer, data.byteOffset, data.byteLength, key)
       )
   }
 }
@@ -55,7 +55,7 @@ exports.verify = function verify(algorithm, data, key, signature) {
         data.byteLength,
         signature.buffer,
         signature.byteOffset,
-        key._key
+        key
       )
   }
 }

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -20,9 +20,7 @@ exports.sign = function sign(algorithm, data, key) {
 
   switch (key._keyType) {
     case ED25519:
-      return Buffer.from(
-        binding.ed25519Sign(data.buffer, data.byteOffset, data.byteLength, key)
-      )
+      return Buffer.from(binding.ed25519Sign(data.buffer, data.byteOffset, data.byteLength, key))
   }
 }
 

--- a/lib/web/algorithm/ed25519.js
+++ b/lib/web/algorithm/ed25519.js
@@ -228,10 +228,10 @@ exports.exportKey = function exportKey(format, key) {
         )
       }
 
-      return data.export()
+      return data.export().buffer
     }
     case 'jwk': {
-      const buffer = Buffer.from(data.export())
+      const buffer = data.export()
 
       if (key.type === 'private') {
         const d = buffer.subarray(0, 32).toString('base64url')

--- a/lib/web/algorithm/ed25519.js
+++ b/lib/web/algorithm/ed25519.js
@@ -58,17 +58,21 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
         }
       }
 
-      keyData = binding.ed25519FromSPKI(keyData.buffer, keyData.byteOffset, keyData.byteLength)
+      {
+        const publicKey = new Ed25519PublicKey()
 
-      return new CryptoKey(
-        'public',
-        extractable,
-        {
-          name: 'Ed25519'
-        },
-        usages,
-        new Ed25519PublicKey(keyData)
-      )
+        binding.ed25519FromSPKI(publicKey, keyData.buffer, keyData.byteOffset, keyData.byteLength)
+
+        return new CryptoKey(
+          'public',
+          extractable,
+          {
+            name: 'Ed25519'
+          },
+          usages,
+          publicKey
+        )
+      }
     case 'pkcs8':
       for (const usage of usages) {
         if (usage !== 'sign') {
@@ -78,17 +82,21 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
         }
       }
 
-      keyData = binding.ed25519FromPKCS8(keyData.buffer, keyData.byteOffset, keyData.byteLength)
+      {
+        const privateKey = new Ed25519PrivateKey()
 
-      return new CryptoKey(
-        'private',
-        extractable,
-        {
-          name: 'Ed25519'
-        },
-        usages,
-        new Ed25519PrivateKey(keyData)
-      )
+        binding.ed25519FromPKCS8(privateKey, keyData.buffer, keyData.byteOffset, keyData.byteLength)
+
+        return new CryptoKey(
+          'private',
+          extractable,
+          {
+            name: 'Ed25519'
+          },
+          usages,
+          privateKey
+        )
+      }
     case 'raw':
       for (const usage of usages) {
         if (usage !== 'verify') {
@@ -154,6 +162,10 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
           throw errors.INVALID_DATA('Key must be 512 bits')
         }
 
+        const handle = new Ed25519PrivateKey(key.buffer)
+
+        key.fill(0)
+
         return new CryptoKey(
           'private',
           extractable,
@@ -161,7 +173,7 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
             name: 'Ed25519'
           },
           usages,
-          new Ed25519PrivateKey(key.buffer)
+          handle
         )
       }
 
@@ -200,7 +212,7 @@ exports.exportKey = function exportKey(format, key) {
         )
       }
 
-      return binding.ed25519ToSPKI(data._key)
+      return binding.ed25519ToSPKI(data)
     case 'pkcs8':
       if (key.type !== 'private') {
         throw errors.INVALID_ACCESS(
@@ -208,7 +220,7 @@ exports.exportKey = function exportKey(format, key) {
         )
       }
 
-      return binding.ed25519ToPKCS8(data._key)
+      return binding.ed25519ToPKCS8(data)
     case 'raw': {
       if (key.type !== 'public') {
         throw errors.INVALID_ACCESS(
@@ -216,10 +228,10 @@ exports.exportKey = function exportKey(format, key) {
         )
       }
 
-      return data._key.slice()
+      return data.export()
     }
     case 'jwk': {
-      const buffer = Buffer.from(data._key)
+      const buffer = Buffer.from(data.export())
 
       if (key.type === 'private') {
         const d = buffer.subarray(0, 32).toString('base64url')

--- a/lib/web/algorithm/ed25519.js
+++ b/lib/web/algorithm/ed25519.js
@@ -49,7 +49,7 @@ exports.generateKey = function generateKey(algorithm, extractable, usages) {
 // https://w3c.github.io/webcrypto/#ed25519-operations-import-key
 exports.importKey = function importKey(format, keyData, algorithm, extractable, usages) {
   switch (format) {
-    case 'spki':
+    case 'spki': {
       for (const usage of usages) {
         if (usage !== 'verify') {
           throw new SyntaxError(
@@ -58,22 +58,21 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
         }
       }
 
-      {
-        const publicKey = new Ed25519PublicKey()
+      const publicKey = new Ed25519PublicKey()
 
-        binding.ed25519FromSPKI(publicKey, keyData.buffer, keyData.byteOffset, keyData.byteLength)
+      binding.ed25519FromSPKI(publicKey, keyData.buffer, keyData.byteOffset, keyData.byteLength)
 
-        return new CryptoKey(
-          'public',
-          extractable,
-          {
-            name: 'Ed25519'
-          },
-          usages,
-          publicKey
-        )
-      }
-    case 'pkcs8':
+      return new CryptoKey(
+        'public',
+        extractable,
+        {
+          name: 'Ed25519'
+        },
+        usages,
+        publicKey
+      )
+    }
+    case 'pkcs8': {
       for (const usage of usages) {
         if (usage !== 'sign') {
           throw new SyntaxError(
@@ -82,21 +81,20 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
         }
       }
 
-      {
-        const privateKey = new Ed25519PrivateKey()
+      const privateKey = new Ed25519PrivateKey()
 
-        binding.ed25519FromPKCS8(privateKey, keyData.buffer, keyData.byteOffset, keyData.byteLength)
+      binding.ed25519FromPKCS8(privateKey, keyData.buffer, keyData.byteOffset, keyData.byteLength)
 
-        return new CryptoKey(
-          'private',
-          extractable,
-          {
-            name: 'Ed25519'
-          },
-          usages,
-          privateKey
-        )
-      }
+      return new CryptoKey(
+        'private',
+        extractable,
+        {
+          name: 'Ed25519'
+        },
+        usages,
+        privateKey
+      )
+    }
     case 'raw':
       for (const usage of usages) {
         if (usage !== 'verify') {

--- a/lib/web/algorithm/hmac.js
+++ b/lib/web/algorithm/hmac.js
@@ -1,19 +1,24 @@
 const crypto = require('../../..')
 const errors = require('../../errors')
+const { SecretKey } = require('../../key')
 const CryptoKey = require('../crypto-key')
 
 // https://w3c.github.io/webcrypto/#hmac
 
 // https://w3c.github.io/webcrypto/#hmac-operations-sign
 exports.sign = function sign(algorithm, key, data) {
-  const digest = crypto.createHmac(key.algorithm.hash.name, key._handle).update(data).digest()
+  const material = Buffer.from(key._handle.export())
+
+  const digest = crypto.createHmac(key.algorithm.hash.name, material).update(data).digest()
 
   return digest.buffer.slice(0, digest.byteLength)
 }
 
 // https://w3c.github.io/webcrypto/#hmac-operations-verify
 exports.verify = function verify(algorithm, key, signature, data) {
-  const digest = crypto.createHmac(key.algorithm.hash.name, key._handle).update(data).digest()
+  const material = Buffer.from(key._handle.export())
+
+  const digest = crypto.createHmac(key.algorithm.hash.name, material).update(data).digest()
 
   if (ArrayBuffer.isView(signature)) {
     signature = Buffer.coerce(signature)
@@ -42,6 +47,10 @@ exports.generateKey = function generateKey(algorithm, extractable, usages) {
 
   const key = crypto.createHmac(hash.name, crypto.randomBytes(length)).digest()
 
+  const handle = new SecretKey(key)
+
+  key.fill(0)
+
   return new CryptoKey(
     'secret',
     extractable,
@@ -53,7 +62,7 @@ exports.generateKey = function generateKey(algorithm, extractable, usages) {
       }
     },
     usages,
-    key
+    handle
   )
 }
 
@@ -70,6 +79,7 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
   if (typeof hash === 'string') hash = { name: hash }
 
   let data
+  let owned = false
 
   switch (format) {
     case 'raw':
@@ -83,6 +93,7 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
       }
 
       data = Buffer.from(jwk.k, 'base64url')
+      owned = true
 
       switch (hash.name.toLowerCase()) {
         case 'sha-1':
@@ -120,6 +131,10 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
     throw errors.INVALID_DATA('Key cannot be empty')
   }
 
+  const handle = new SecretKey(data)
+
+  if (owned) data.fill(0)
+
   return new CryptoKey(
     'secret',
     extractable,
@@ -131,13 +146,13 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
       }
     },
     usages,
-    data
+    handle
   )
 }
 
 // https://w3c.github.io/webcrypto/#hmac-operations-export-key
 exports.exportKey = function exportKey(format, key) {
-  const data = key._handle
+  const data = Buffer.from(key._handle.export())
 
   switch (format) {
     case 'raw':

--- a/lib/web/algorithm/hmac.js
+++ b/lib/web/algorithm/hmac.js
@@ -7,7 +7,7 @@ const CryptoKey = require('../crypto-key')
 
 // https://w3c.github.io/webcrypto/#hmac-operations-sign
 exports.sign = function sign(algorithm, key, data) {
-  const material = Buffer.from(key._handle.export())
+  const material = key._handle.export()
 
   const digest = crypto.createHmac(key.algorithm.hash.name, material).update(data).digest()
 
@@ -16,7 +16,7 @@ exports.sign = function sign(algorithm, key, data) {
 
 // https://w3c.github.io/webcrypto/#hmac-operations-verify
 exports.verify = function verify(algorithm, key, signature, data) {
-  const material = Buffer.from(key._handle.export())
+  const material = key._handle.export()
 
   const digest = crypto.createHmac(key.algorithm.hash.name, material).update(data).digest()
 
@@ -152,7 +152,7 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
 
 // https://w3c.github.io/webcrypto/#hmac-operations-export-key
 exports.exportKey = function exportKey(format, key) {
-  const data = Buffer.from(key._handle.export())
+  const data = key._handle.export()
 
   switch (format) {
     case 'raw':

--- a/lib/web/algorithm/pbkdf2.js
+++ b/lib/web/algorithm/pbkdf2.js
@@ -23,7 +23,7 @@ exports.deriveBits = function deriveBits(algorithm, key, length) {
 
   if (typeof hash === 'string') hash = { name: hash }
 
-  const material = Buffer.from(key._handle.export())
+  const material = key._handle.export()
 
   const result = crypto.pbkdf2(
     material,

--- a/lib/web/algorithm/pbkdf2.js
+++ b/lib/web/algorithm/pbkdf2.js
@@ -1,5 +1,6 @@
 const crypto = require('../../..')
 const errors = require('../../errors')
+const { SecretKey } = require('../../key')
 const CryptoKey = require('../crypto-key')
 
 // https://w3c.github.io/webcrypto/#pbkdf2
@@ -22,8 +23,10 @@ exports.deriveBits = function deriveBits(algorithm, key, length) {
 
   if (typeof hash === 'string') hash = { name: hash }
 
+  const material = Buffer.from(key._handle.export())
+
   const result = crypto.pbkdf2(
-    key._handle,
+    material,
     algorithm.salt,
     algorithm.iterations,
     length / 8,
@@ -58,6 +61,6 @@ exports.importKey = function importKey(format, keyData, algorithm, extractable, 
       name: 'PBKDF2'
     },
     usages,
-    keyData
+    new SecretKey(keyData)
   )
 }

--- a/lib/web/crypto-key.js
+++ b/lib/web/crypto-key.js
@@ -28,6 +28,22 @@ module.exports = class CryptoKey {
     return this._usages
   }
 
+  get destroyed() {
+    return this._handle === null
+  }
+
+  destroy() {
+    if (this._handle === null) return
+
+    this._handle.destroy()
+
+    this._handle = null
+  }
+
+  [Symbol.dispose]() {
+    this.destroy()
+  }
+
   [Symbol.for('bare.inspect')]() {
     return {
       __proto__: { constructor: CryptoKey },

--- a/test/key.js
+++ b/test/key.js
@@ -32,6 +32,31 @@ test('ed25519, destroy is idempotent', (t) => {
   t.is(privateKey.destroyed, true)
 })
 
+test('ed25519, signing with destroyed key throws', (t) => {
+  const { privateKey } = crypto.generateKeyPair('ed25519')
+
+  privateKey.destroy()
+
+  t.exception(
+    () => crypto.sign(null, Buffer.from('hello'), privateKey),
+    /Key has been destroyed/
+  )
+})
+
+test('ed25519, verifying with destroyed key throws', (t) => {
+  const { publicKey, privateKey } = crypto.generateKeyPair('ed25519')
+
+  const data = Buffer.from('hello')
+  const signature = crypto.sign(null, data, privateKey)
+
+  publicKey.destroy()
+
+  t.exception(
+    () => crypto.verify(null, data, publicKey, signature),
+    /Key has been destroyed/
+  )
+})
+
 test('ed25519, using disposes key', (t) => {
   let key
 

--- a/test/key.js
+++ b/test/key.js
@@ -11,3 +11,38 @@ test('generateKeyPair, ed25519', (t) => {
 test('type guards', (t) => {
   t.exception(() => crypto.generateKeyPair(NaN), /AssertionError/)
 })
+
+test('ed25519, destroy zeroes private key', (t) => {
+  const { privateKey } = crypto.generateKeyPair('ed25519')
+
+  const before = new Uint8Array(privateKey.export())
+
+  t.ok(before.some((b) => b !== 0))
+
+  privateKey.destroy()
+
+  t.is(privateKey.destroyed, true)
+  t.exception(() => privateKey.export(), /Key has been destroyed/)
+})
+
+test('ed25519, destroy is idempotent', (t) => {
+  const { privateKey } = crypto.generateKeyPair('ed25519')
+
+  privateKey.destroy()
+  privateKey.destroy()
+
+  t.is(privateKey.destroyed, true)
+})
+
+test('ed25519, using disposes key', (t) => {
+  let key
+
+  {
+    using privateKey = crypto.generateKeyPair('ed25519').privateKey
+
+    key = privateKey
+    t.ok(new Uint8Array(key.export()).some((b) => b !== 0))
+  }
+
+  t.is(key.destroyed, true)
+})

--- a/test/key.js
+++ b/test/key.js
@@ -15,9 +15,7 @@ test('type guards', (t) => {
 test('ed25519, destroy zeroes private key', (t) => {
   const { privateKey } = crypto.generateKeyPair('ed25519')
 
-  const before = new Uint8Array(privateKey.export())
-
-  t.ok(before.some((b) => b !== 0))
+  t.ok(privateKey.export().some((b) => b !== 0))
 
   privateKey.destroy()
 
@@ -41,7 +39,7 @@ test('ed25519, using disposes key', (t) => {
     using privateKey = crypto.generateKeyPair('ed25519').privateKey
 
     key = privateKey
-    t.ok(new Uint8Array(key.export()).some((b) => b !== 0))
+    t.ok(key.export().some((b) => b !== 0))
   }
 
   t.is(key.destroyed, true)

--- a/test/key.js
+++ b/test/key.js
@@ -37,10 +37,7 @@ test('ed25519, signing with destroyed key throws', (t) => {
 
   privateKey.destroy()
 
-  t.exception(
-    () => crypto.sign(null, Buffer.from('hello'), privateKey),
-    /Key has been destroyed/
-  )
+  t.exception(() => crypto.sign(null, Buffer.from('hello'), privateKey), /Key has been destroyed/)
 })
 
 test('ed25519, verifying with destroyed key throws', (t) => {
@@ -51,10 +48,7 @@ test('ed25519, verifying with destroyed key throws', (t) => {
 
   publicKey.destroy()
 
-  t.exception(
-    () => crypto.verify(null, data, publicKey, signature),
-    /Key has been destroyed/
-  )
+  t.exception(() => crypto.verify(null, data, publicKey, signature), /Key has been destroyed/)
 })
 
 test('ed25519, using disposes key', (t) => {

--- a/test/web.js
+++ b/test/web.js
@@ -368,7 +368,7 @@ test('subtle, destroy zeroes hmac key', async (t) => {
   const inner = key._handle
 
   t.is(inner.destroyed, false)
-  t.ok(new Uint8Array(inner.export()).some((b) => b !== 0))
+  t.ok(inner.export().some((b) => b !== 0))
 
   key.destroy()
 

--- a/test/web.js
+++ b/test/web.js
@@ -377,11 +377,10 @@ test('subtle, destroy zeroes hmac key', async (t) => {
 })
 
 test('subtle, destroy delegates for ed25519 key', async (t) => {
-  const { privateKey } = await webcrypto.subtle.generateKey(
-    { name: 'Ed25519' },
-    false,
-    ['sign', 'verify']
-  )
+  const { privateKey } = await webcrypto.subtle.generateKey({ name: 'Ed25519' }, false, [
+    'sign',
+    'verify'
+  ])
 
   const inner = privateKey._handle
 

--- a/test/web.js
+++ b/test/web.js
@@ -357,3 +357,68 @@ test('subtle, digest sha256', async (t) => {
     'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
   )
 })
+
+test('subtle, destroy zeroes hmac key', async (t) => {
+  const key = await webcrypto.subtle.generateKey(
+    { name: 'HMAC', hash: 'SHA-256', length: 256 },
+    true,
+    ['sign']
+  )
+
+  const inner = key._handle
+
+  t.is(inner.destroyed, false)
+  t.ok(new Uint8Array(inner.export()).some((b) => b !== 0))
+
+  key.destroy()
+
+  t.is(key.destroyed, true)
+  t.is(inner.destroyed, true)
+})
+
+test('subtle, destroy delegates for ed25519 key', async (t) => {
+  const { privateKey } = await webcrypto.subtle.generateKey(
+    { name: 'Ed25519' },
+    false,
+    ['sign', 'verify']
+  )
+
+  const inner = privateKey._handle
+
+  t.is(typeof inner.destroy, 'function')
+  t.is(inner.destroyed, false)
+
+  privateKey.destroy()
+
+  t.is(privateKey.destroyed, true)
+  t.is(inner.destroyed, true)
+})
+
+test('subtle, destroy is idempotent', async (t) => {
+  const key = await webcrypto.subtle.generateKey(
+    { name: 'HMAC', hash: 'SHA-256', length: 256 },
+    true,
+    ['sign']
+  )
+
+  key.destroy()
+  key.destroy()
+
+  t.is(key.destroyed, true)
+})
+
+test('subtle, using disposes key', async (t) => {
+  const key = await webcrypto.subtle.generateKey(
+    { name: 'HMAC', hash: 'SHA-256', length: 256 },
+    true,
+    ['sign']
+  )
+
+  {
+    using k = key
+
+    t.is(k.destroyed, false)
+  }
+
+  t.is(key.destroyed, true)
+})


### PR DESCRIPTION
This also moves all key material to the C heap and zeroes the allocations when the JavaScript handles are garbage collected.